### PR TITLE
Add support for _timestamp field to @ElasticsearchMapping annotation.

### DIFF
--- a/src/main/java/com/github/tlrx/elasticsearch/test/annotations/ElasticsearchMapping.java
+++ b/src/main/java/com/github/tlrx/elasticsearch/test/annotations/ElasticsearchMapping.java
@@ -48,4 +48,21 @@ public @interface ElasticsearchMapping {
      * Time To Live value
      */
     String ttlValue() default "";
+
+    /**
+     * Index the document's timestamp using the _timestamp field (default to false)
+     */
+    boolean timestamp() default false;
+
+    /**
+     * The path used to extract the timestamp from the document
+     * (default to "", meaning the "_timestamp" field should be explicitly set when indexing)
+     */
+    String timestampPath() default "";
+
+    /**
+     * The date format of the "_timestamp" field (default to "dateOptionalTime")
+     */
+    String timestampFormat() default "dateOptionalTime";
+
 }

--- a/src/main/java/com/github/tlrx/elasticsearch/test/support/junit/handlers/annotations/ElasticsearchIndexAnnotationHandler.java
+++ b/src/main/java/com/github/tlrx/elasticsearch/test/support/junit/handlers/annotations/ElasticsearchIndexAnnotationHandler.java
@@ -277,6 +277,18 @@ public class ElasticsearchIndexAnnotationHandler extends AbstractAnnotationHandl
                 builder = builder.endObject();
             }
 
+            if (mapping.timestamp()) {
+                builder = builder.startObject("_timestamp").field("enabled",
+                        String.valueOf(mapping.timestamp()));
+                if (mapping.timestampPath().length() > 0) {
+                    builder = builder.field("path", mapping.timestampPath());
+                }
+                if (mapping.timestampFormat().length() > 0) {
+                    builder = builder.field("format", mapping.timestampFormat());
+                }
+                builder = builder.endObject();
+            }
+
             builder = builder.startObject("properties");
 
             // Manage fields

--- a/src/test/java/com/github/tlrx/elasticsearch/test/annotations/ElasticsearchMappingAnnotationTest.java
+++ b/src/test/java/com/github/tlrx/elasticsearch/test/annotations/ElasticsearchMappingAnnotationTest.java
@@ -42,11 +42,15 @@ public class ElasticsearchMappingAnnotationTest {
                             compress = false,
                             ttl = true,
                             ttlValue = "2d",
+                            timestamp = true,
+                            timestampFormat = "YYYY-MM-dd",
+                            timestampPath = "publication_date",
                             properties = {
                                     @ElasticsearchMappingField(name = "title", store = Store.Yes, type = Types.String),
                                     @ElasticsearchMappingField(name = "author", store = Store.No, type = Types.String, index = Index.Not_Analyzed),
                                     @ElasticsearchMappingField(name = "description", store = Store.Yes, type = Types.String, index = Index.Analyzed, analyzerName = "standard"),
-                                    @ElasticsearchMappingField(name = "role", store = Store.No, type = Types.String, index = Index.Analyzed, indexAnalyzerName = "keyword", searchAnalyzerName = "standard")
+                                    @ElasticsearchMappingField(name = "role", store = Store.No, type = Types.String, index = Index.Analyzed, indexAnalyzerName = "keyword", searchAnalyzerName = "standard"),
+                                    @ElasticsearchMappingField(name = "publication_date", store = Store.No, type = Types.Date, index = Index.Not_Analyzed)
                             },
                             propertiesMulti = {
                                     @ElasticsearchMappingMultiField(name = "name",
@@ -89,6 +93,13 @@ public class ElasticsearchMappingAnnotationTest {
             assertNotNull("_ttl must exists", ttl);
             assertEquals(Boolean.TRUE, ttl.get("enabled"));
             assertEquals(172800000, ttl.get("default"));
+
+            // Check _timestamp
+            Map<String, Object> timestamp = (Map<String, Object>) def.get("_timestamp");
+            assertNotNull("_timestamp must exist", timestamp);
+            assertEquals(Boolean.TRUE, timestamp.get("enabled"));
+            assertEquals("YYYY-MM-dd", timestamp.get("format"));
+            assertEquals("publication_date", timestamp.get("path"));
 
             // Check properties
             Map<String, Object> properties = (Map<String, Object>) def.get("properties");


### PR DESCRIPTION
Example usage:

```
@ElasticsearchMapping(timestamp = true,
                      timestampFormat = "YYYY-MM-dd",
                      timestampPath = "publication_date",
                      properties = {...})
```

By default the "_timestamp" field of a mapping is disabled in Elasticsearch, and it's currently not possible to enable it using the `@ElasticsearchMapping` annotation. I've added a few fields to the annotation to make it possible to enable and configure it.

Relevant ES documentation page: http://www.elasticsearch.org/guide/reference/mapping/timestamp-field/
