### PR TITLE
Support for Elasticsearch 0.90.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>0.90.0.Beta1</elasticsearch.version>
+        <elasticsearch.version>0.90.1</elasticsearch.version>
         <github.global.server>github</github.global.server>
     </properties>
 

--- a/src/test/java/com/github/tlrx/elasticsearch/test/EsSetupTest.java
+++ b/src/test/java/com/github/tlrx/elasticsearch/test/EsSetupTest.java
@@ -127,6 +127,21 @@ public class EsSetupTest {
         assertFalse(esSetup.exists("catalog-2013"));
 
     }
+    
+    @Test
+    public void testSecondRequests() {
+
+        // Test second test access to Client
+        assertNotNull(esSetup.client());
+
+        // test second access to exists()
+        assertTrue(esSetup.exists("catalog-2009"));
+        assertTrue(esSetup.exists("catalog-2010"));
+        assertTrue(esSetup.exists("catalog-2011"));
+        assertTrue(esSetup.exists("catalog-2012"));
+        assertTrue(esSetup.exists("catalog-2013"));
+        
+    }
 
     @After
     public void tearDown() throws Exception {


### PR DESCRIPTION
- Changed ES version to 0.90.1
- Added second test method for `EsSetupTest`
